### PR TITLE
chore(irc): rename home::symlink to home::symlinks

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -29,12 +29,12 @@ p6df::modules::irc::external::brews() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::irc::home::symlink()
+# Function: p6df::modules::irc::home::symlinks()
 #
 #  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
-p6df::modules::irc::home::symlink() {
+p6df::modules::irc::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-irc/share/irssi" ".irssi"
 


### PR DESCRIPTION
## What
Rename singular to plural so framework auto-discovers it.

## Why
p6df-core dispatches home::symlinks (plural) only.

## Test plan
\`p6df home symlinks\` works correctly.

## Dependencies
None