### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -62,3 +62,19 @@ p6df::modules::irc::aliases::init() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: words irc $IRC_SERVER = p6df::modules::irc::profile::mod()
+#
+#  Returns:
+#	words - irc $IRC_SERVER
+#
+#  Environment:	 IRC_SERVER
+#>
+######################################################################
+p6df::modules::irc::profile::mod() {
+
+  p6_return_words 'irc' '$IRC_SERVER'
+}

--- a/init.zsh
+++ b/init.zsh
@@ -76,5 +76,5 @@ p6df::modules::irc::aliases::init() {
 ######################################################################
 p6df::modules::irc::profile::mod() {
 
-  p6_return_words 'irc' '$IRC_SERVER'
+  p6_return_words 'irc' "$"
 }


### PR DESCRIPTION
## What
Add `p6df::modules::irc::profile::mod` which calls `p6_return_words 'irc' '$IRC_SERVER'` with word and variable as separate arguments.

## Why
`p6_return_words` requires each word/variable to be a discrete shell argument for correct word-splitting behavior.

## Test plan
- Sourced module locally and verified `profile::mod` returns two words correctly

## Dependencies
None