### PR TITLE
fix(profile): use IRCNICK and IRCHOST env vars in profile mod

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -76,5 +76,5 @@ p6df::modules::irc::aliases::init() {
 ######################################################################
 p6df::modules::irc::profile::mod() {
 
-  p6_return_words 'irc' "$"
+  p6_return_words 'irc' '$IRCNICK' '$IRCHOST'
 }


### PR DESCRIPTION
## What
Fix `p6df::modules::irc::profile::mod` to pass `$IRCNICK` and `$IRCHOST` environment variables instead of the broken `"$"` literal.

## Why
The previous value `"$"` was a broken placeholder. The correct IRC environment variables `$IRCNICK` and `$IRCHOST` are now referenced so the profile module exposes them properly.

## Test plan
- Reviewed diff; single-line fix replacing `"$"` with `'$IRCNICK' '$IRCHOST'`
- No functional regressions expected; this fixes a non-functional placeholder

## Dependencies
None