### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,27 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::irc::deps()
+#
+#>
+######################################################################
 p6df::modules::irc::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-shell
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::irc::aliases::init(_module, dir)
+#
+#  Args:
+#	_module -
+#	dir -
+#
+#>
 ######################################################################
 p6df::modules::irc::aliases::init() {
   local _module="$1"
@@ -19,6 +35,13 @@ p6df::modules::irc::aliases::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::irc::home::symlinks()
+#
+#  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
 p6df::modules::irc::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-irc/share/irssi" ".irssi"
@@ -27,6 +50,12 @@ p6df::modules::irc::home::symlinks() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::irc::external::brews()
+#
+#>
+######################################################################
 p6df::modules::irc::external::brews() {
 
   p6df::core::homebrew::cli::brew::install irssi
@@ -34,40 +63,6 @@ p6df::modules::irc::external::brews() {
   p6_return_void
 }
 
-######################################################################
-p6df::modules::irc::profile::mod() {
-
-  p6_return_words 'irc' '$IRCNICK' '$IRCHOST'
-}
-######################################################################
-#<
-#
-# Function: p6df::modules::irc::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::irc::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::irc::home::symlinks()
-#
-#  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::irc::aliases::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
-#
-#>
 ######################################################################
 #<
 #
@@ -78,3 +73,8 @@ p6df::modules::irc::profile::mod() {
 #
 #  Environment:	 IRC_SERVER
 #>
+######################################################################
+p6df::modules::irc::profile::mod() {
+
+  p6_return_words 'irc' '$IRCNICK' '$IRCHOST'
+}

--- a/init.zsh
+++ b/init.zsh
@@ -1,56 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::irc::deps()
-#
-#>
-######################################################################
 p6df::modules::irc::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-shell
   )
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::irc::external::brews()
-#
-#>
-######################################################################
-p6df::modules::irc::external::brews() {
-
-  p6df::core::homebrew::cli::brew::install irssi
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::irc::home::symlinks()
-#
-#  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-p6df::modules::irc::home::symlinks() {
-
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-irc/share/irssi" ".irssi"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::irc::aliases::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
-#
-#>
 ######################################################################
 p6df::modules::irc::aliases::init() {
   local _module="$1"
@@ -64,6 +19,56 @@ p6df::modules::irc::aliases::init() {
 }
 
 ######################################################################
+p6df::modules::irc::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-irc/share/irssi" ".irssi"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::irc::external::brews() {
+
+  p6df::core::homebrew::cli::brew::install irssi
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::irc::profile::mod() {
+
+  p6_return_words 'irc' '$IRCNICK' '$IRCHOST'
+}
+######################################################################
+#<
+#
+# Function: p6df::modules::irc::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::irc::external::brews()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::irc::home::symlinks()
+#
+#  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::irc::aliases::init(_module, dir)
+#
+#  Args:
+#	_module -
+#	dir -
+#
+#>
+######################################################################
 #<
 #
 # Function: words irc $IRC_SERVER = p6df::modules::irc::profile::mod()
@@ -73,8 +78,3 @@ p6df::modules::irc::aliases::init() {
 #
 #  Environment:	 IRC_SERVER
 #>
-######################################################################
-p6df::modules::irc::profile::mod() {
-
-  p6_return_words 'irc' '$IRCNICK' '$IRCHOST'
-}


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None